### PR TITLE
Load graph data via fetch

### DIFF
--- a/dash/pages/causal-graph.jsx
+++ b/dash/pages/causal-graph.jsx
@@ -1,47 +1,80 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import cytoscape from "cytoscape";
-import causalData from "../../data/causal-power-imbalance.json";
+// import causalData from "../../data/causal-power-imbalance.json";
 
 const CausalGraph = () => {
   const cyRef = useRef(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
-    const cy = cytoscape({
-      container: cyRef.current,
-      elements: [...causalData.nodes, ...causalData.edges],
-      style: [
-        {
-          selector: "node",
-          style: {
-            label: "data(label)",
-            "background-color": "#007bff",
-            width: 50,
-            height: 50,
-          },
-        },
-        {
-          selector: "edge",
-          style: {
-            width: 4,
-            "line-color": "mapData(type, 'positive', 'green', 'negative', 'red', 'neutral', 'gray')",
-            "target-arrow-color": "mapData(type, 'positive', 'green', 'negative', 'red', 'neutral', 'gray')",
-            "target-arrow-shape": "triangle",
-            "curve-style": "bezier",
-          },
-        },
-      ],
-      layout: { name: "cose" },
-    });
+    let cy;
+    fetch("/data/causal-power-imbalance.json")
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error("Network response was not ok");
+        }
+        return res.json();
+      })
+      .then((data) => {
+        console.log(data);
+        if (!data.nodes || !data.edges) {
+          throw new Error("Invalid data format");
+        }
+        cy = cytoscape({
+          container: cyRef.current,
+          elements: [...data.nodes, ...data.edges],
+          style: [
+            {
+              selector: "node",
+              style: {
+                label: "data(label)",
+                "background-color": "#007bff",
+                width: 50,
+                height: 50,
+              },
+            },
+            {
+              selector: "edge",
+              style: {
+                width: 4,
+                "line-color": "mapData(type, 'positive', 'green', 'negative', 'red', 'neutral', 'gray')",
+                "target-arrow-color": "mapData(type, 'positive', 'green', 'negative', 'red', 'neutral', 'gray')",
+                "target-arrow-shape": "triangle",
+                "curve-style": "bezier",
+              },
+            },
+          ],
+          layout: { name: "cose" },
+        });
 
-    cy.on("tap", "node", (evt) => {
-      const data = evt.target.data();
-      alert(`${data.label}\n${data.description}\n${data.resources?.join(", ") || ""}`);
-    });
+        cy.on("tap", "node", (evt) => {
+          const nodeData = evt.target.data();
+          alert(`${nodeData.label}\n${nodeData.description}\n${nodeData.resources?.join(", ") || ""}`);
+        });
+      })
+      .catch((err) => {
+        console.error("Error loading graph data", err);
+        setError("خطا در بارگذاری داده‌های نمودار");
+      })
+      .finally(() => {
+        setLoading(false);
+      });
 
-    return () => cy.destroy();
+    return () => {
+      if (cy) {
+        cy.destroy();
+      }
+    };
   }, []);
 
-  return <div ref={cyRef} style={{ width: "100%", height: "600px" }} />;
+  return (
+    <div className="relative w-full h-[600px]">
+      {loading && <div className="absolute inset-0 flex items-center justify-center">در حال بارگذاری...</div>}
+      {error && <div className="absolute inset-0 flex items-center justify-center text-red-600">{error}</div>}
+      <div ref={cyRef} className="w-full h-full" />
+    </div>
+  );
 };
 
 export default CausalGraph;


### PR DESCRIPTION
## Summary
- fetch causal graph JSON at runtime and log it
- show loading and error messages in the UI

## Testing
- `npm --prefix cld-tool run lint` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684707fdec1c83288f4fea142bb19a2c