### PR TITLE
Fix causal-graph page imports

### DIFF
--- a/dash/causal-graph.html
+++ b/dash/causal-graph.html
@@ -8,15 +8,15 @@
     <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
     <script src="https://unpkg.com/cytoscape@3/dist/cytoscape.min.js"></script>
-    <script src="./causal-graph.compiled.js"></script>
+    <script crossorigin src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
 </head>
 <body class="p-4">
     <div id="root" class="w-full h-[600px]"></div>
 
-    <script>
-      const CausalGraph = CausalGraphModule.default;
+    <script type="text/babel" data-type="module">
+      import CausalGraph from "./pages/causal-graph.js";
       ReactDOM.createRoot(document.getElementById('root')).render(
-        React.createElement(CausalGraph)
+        <CausalGraph />
       );
     </script>
 </body>


### PR DESCRIPTION
## Summary
- use Babel and ES module import for causal-graph page

## Testing
- `npm -C cld-tool test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684717cb973c8328964a53b193241ad8