### PR TITLE
Fix causal graph js to load via fetch without React

### DIFF
--- a/dash/causal-graph.html
+++ b/dash/causal-graph.html
@@ -5,19 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>نمودار علّی عرضه و تقاضای برق</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
-    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
     <script src="https://unpkg.com/cytoscape@3/dist/cytoscape.min.js"></script>
-    <script crossorigin src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
 </head>
 <body class="p-4">
-    <div id="root" class="w-full h-[600px]"></div>
-
-    <script type="text/babel" data-type="module">
-      import CausalGraph from "./pages/causal-graph.js";
-      ReactDOM.createRoot(document.getElementById('root')).render(
-        <CausalGraph />
-      );
+    <div id="cy" style="width:100%; height:600px"></div>
+    <script src="pages/causal-graph.js"></script>
+    <script>
+      initCausalGraph('../data/causal-power-imbalance.json');
     </script>
 </body>
 </html>

--- a/dash/pages/causal-graph.js
+++ b/dash/pages/causal-graph.js
@@ -1,82 +1,58 @@
-import React, { useEffect, useRef, useState } from "react";
-import cytoscape from "cytoscape";
-// import causalData from "../../data/causal-power-imbalance.json";
+function initCausalGraph(dataPath) {
+  const container = document.getElementById('cy');
+  if (!container) {
+    console.error('Container element with id "cy" not found');
+    return;
+  }
 
-const CausalGraph = () => {
-  const cyRef = useRef(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+  const loadingEl = document.createElement('div');
+  loadingEl.textContent = 'در حال بارگذاری...';
+  loadingEl.className = 'text-center my-4';
+  container.appendChild(loadingEl);
 
-  useEffect(() => {
-    let cy;
-    fetch("/data/causal-power-imbalance.json")
-      .then((res) => {
-        if (!res.ok) {
-          throw new Error("Network response was not ok");
-        }
-        return res.json();
-      })
-      .then((data) => {
-        console.log('Graph data:', data);
-        console.log('Nodes:', data.nodes);
-        console.log('Edges:', data.edges);
-        if (!data.nodes || !data.edges) {
-          throw new Error("Invalid data format");
-        }
-        cy = cytoscape({
-          container: cyRef.current,
-          elements: [...data.nodes, ...data.edges],
-          style: [
-            {
-              selector: "node",
-              style: {
-                label: "data(label)",
-                "background-color": "#007bff",
-                width: 50,
-                height: 50,
-              },
-            },
-            {
-              selector: "edge",
-              style: {
-                width: 4,
-                "line-color": "mapData(type, 'positive', 'green', 'negative', 'red', 'neutral', 'gray')",
-                "target-arrow-color": "mapData(type, 'positive', 'green', 'negative', 'red', 'neutral', 'gray')",
-                "target-arrow-shape": "triangle",
-                "curve-style": "bezier",
-              },
-            },
-          ],
-          layout: { name: "cose" },
-        });
-
-        cy.on("tap", "node", (evt) => {
-          const nodeData = evt.target.data();
-          alert(`${nodeData.label}\n${nodeData.description}\n${nodeData.resources?.join(", ") || ""}`);
-        });
-      })
-      .catch((err) => {
-        console.error("Error loading graph data", err);
-        setError("خطا در بارگذاری داده‌های نمودار");
-      })
-      .finally(() => {
-        setLoading(false);
+  fetch(dataPath)
+    .then(function(res) { return res.json(); })
+    .then(function(causalData) {
+      console.log(causalData); // log loaded data
+      const cy = cytoscape({
+        container: container,
+        elements: [].concat(causalData.nodes || [], causalData.edges || []),
+        style: [
+          {
+            selector: 'node',
+            style: {
+              label: 'data(label)',
+              'background-color': '#007bff',
+              width: 50,
+              height: 50
+            }
+          },
+          {
+            selector: 'edge',
+            style: {
+              width: 4,
+              'line-color': "mapData(type, 'positive', 'green', 'negative', 'red', 'neutral', 'gray')",
+              'target-arrow-color': "mapData(type, 'positive', 'green', 'negative', 'red', 'neutral', 'gray')",
+              'target-arrow-shape': 'triangle',
+              'curve-style': 'bezier'
+            }
+          }
+        ],
+        layout: { name: 'cose' }
       });
 
-    return () => {
-      if (cy) {
-        cy.destroy();
-      }
-    };
-  }, []);
+      cy.on('tap', 'node', function(evt) {
+        var d = evt.target.data();
+        alert(d.label + '\n' + d.description + '\n' + (d.resources ? d.resources.join(', ') : ''));
+      });
+    })
+    .catch(function(err) {
+      console.error('Error loading graph data', err);
+      container.innerHTML = '<div class="text-red-600">خطا در بارگذاری داده‌های نمودار</div>';
+    })
+    .finally(function() {
+      loadingEl.remove();
+    });
+}
 
-  return (
-    <div className="relative w-full h-[600px]">
-      {loading && <div className="absolute inset-0 flex items-center justify-center">در حال بارگذاری...</div>}
-      {error && <div className="absolute inset-0 flex items-center justify-center text-red-600">{error}</div>}
-      <div ref={cyRef} className="w-full h-full" />
-    </div>
-  );
-};
-
-export default CausalGraph;
+window.initCausalGraph = initCausalGraph;

--- a/index.html
+++ b/index.html
@@ -6,9 +6,6 @@
     <title>تحلیل تعاملی بحران عدم تعادل برق ایران</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
-    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
-    <script crossorigin src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
     <script src="https://unpkg.com/cytoscape@3/dist/cytoscape.min.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -282,9 +279,10 @@
 
         });
     </script>
-    <script type="text/babel" data-type="module">
-      import CausalGraph from "./dash/pages/causal-graph.js";
-      ReactDOM.createRoot(document.getElementById("causal-root")).render(<CausalGraph />);
+
+    <script src="./dash/pages/causal-graph.js"></script>
+    <script>
+      initCausalGraph("data/causal-power-imbalance.json");
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove React usage and convert `dash/pages/causal-graph.js` to plain JS
- update `dash/causal-graph.html` to load JS directly
- drop React and Babel from `index.html` and use new init function

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68471adbe6b88328896353f856a93e7d