### PR TITLE
Add sidebar info panel for causal graph nodes

### DIFF
--- a/dash/causal-graph.html
+++ b/dash/causal-graph.html
@@ -9,6 +9,15 @@
 </head>
 <body class="p-4">
     <div id="cy" style="width:100%; height:600px"></div>
+    <!-- Sidebar for node details -->
+    <div id="node-info-sidebar" class="fixed top-0 right-0 h-full w-80 max-w-sm bg-white shadow-lg p-4 transform translate-x-full transition-transform z-50">
+        <div class="flex items-center justify-between mb-4 border-b pb-2">
+            <h2 id="node-info-title" class="font-bold text-lg"></h2>
+            <button id="node-info-close" class="text-slate-500 hover:text-slate-700">&times;</button>
+        </div>
+        <p id="node-info-desc" class="text-sm text-slate-700 mb-4"></p>
+        <ul id="node-info-resources" class="list-disc pr-5 space-y-2 text-sm"></ul>
+    </div>
     <script src="pages/causal-graph.js"></script>
     <script>
       initCausalGraph('../data/causal-power-imbalance.json');

--- a/dash/pages/causal-graph.js
+++ b/dash/pages/causal-graph.js
@@ -5,6 +5,17 @@ function initCausalGraph(dataPath) {
     return;
   }
 
+  const sidebar = document.getElementById('node-info-sidebar');
+  const titleEl = document.getElementById('node-info-title');
+  const descEl = document.getElementById('node-info-desc');
+  const resEl = document.getElementById('node-info-resources');
+  const closeBtn = document.getElementById('node-info-close');
+  if (closeBtn && sidebar) {
+    closeBtn.addEventListener('click', function() {
+      sidebar.classList.add('translate-x-full');
+    });
+  }
+
   const loadingEl = document.createElement('div');
   loadingEl.textContent = 'در حال بارگذاری...';
   loadingEl.className = 'text-center my-4';
@@ -42,8 +53,26 @@ function initCausalGraph(dataPath) {
       });
 
       cy.on('tap', 'node', function(evt) {
+        if (!sidebar) return;
         var d = evt.target.data();
-        alert(d.label + '\n' + d.description + '\n' + (d.resources ? d.resources.join(', ') : ''));
+        if (titleEl) titleEl.textContent = d.label || '';
+        if (descEl) descEl.textContent = d.description || '';
+        if (resEl) {
+          resEl.innerHTML = '';
+          if (d.resources && Array.isArray(d.resources)) {
+            d.resources.forEach(function(url) {
+              var li = document.createElement('li');
+              var a = document.createElement('a');
+              a.href = url;
+              a.textContent = url;
+              a.target = '_blank';
+              a.className = 'text-teal-700 hover:underline';
+              li.appendChild(a);
+              resEl.appendChild(li);
+            });
+          }
+        }
+        sidebar.classList.remove('translate-x-full');
       });
     })
     .catch(function(err) {


### PR DESCRIPTION
## Summary
- add sidebar markup to `dash/causal-graph.html`
- show node info in sidebar instead of `alert`

## Testing
- `npm run lint` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68471d8a3c30832886064963b510327a