### PR TITLE
Add logging and cache-bust for causal graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,24 @@ This repository hosts a small static dashboard to visualise causal relationships
 
 ## Running locally
 
-Use a simple HTTP server from the repository root so that the JSON data can be fetched correctly:
+Use a simple HTTP server from the repository root so that the JSON data can be fetched correctly. Opening the HTML file directly with `file://` will lead to a `Failed to fetch` error because the graph data is loaded via `fetch`:
 
 ```bash
 # with Python
 python3 -m http.server 8000
-# then open http://localhost:8000/index.html
+# then open http://localhost:8000/index.html in your browser
 ```
 
 Alternatively, use any other static server (e.g. `npx serve`). Opening the HTML files directly via `file://` will not work because the graph data is loaded with `fetch`.
+
+After the page loads, open your browser's developer console. The script logs the fetched data and the number of nodes and edges. You can also run the following commands in the console to verify the numbers match your JSON file:
+
+```js
+cy.nodes().length
+cy.edges().length
+```
+
+If the counts differ, check that `data/causal-power-imbalance.json` is up to date and that the IDs in `edges` exactly match the node IDs.
 
 
 ## Features

--- a/dash/pages/causal-graph.js
+++ b/dash/pages/causal-graph.js
@@ -48,7 +48,8 @@ function initCausalGraph(dataPath) {
   fetch(dataPath)
     .then(function(res) { return res.json(); })
     .then(function(causalData) {
-      console.log(causalData); // log loaded data
+      // Log the raw data to verify it loaded correctly
+      console.log('Fetched graph data:', causalData);
       const cy = cytoscape({
         container: container,
         elements: [],
@@ -77,6 +78,9 @@ function initCausalGraph(dataPath) {
       });
 
       addDataToGraph(cy, causalData);
+
+      // log element counts to check against the JSON file
+      console.log('Graph now has', cy.nodes().length, 'nodes and', cy.edges().length, 'edges');
 
       cy.on('tap', 'node', function(evt) {
         if (!sidebar) return;

--- a/data/simple-graph.json
+++ b/data/simple-graph.json
@@ -1,0 +1,9 @@
+{
+  "nodes": [
+    { "data": { "id": "a", "label": "گره A" } },
+    { "data": { "id": "b", "label": "گره B" } }
+  ],
+  "edges": [
+    { "data": { "id": "ab", "source": "a", "target": "b", "type": "positive" } }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -292,7 +292,8 @@
 
     <script src="./dash/pages/causal-graph.js"></script>
     <script>
-      initCausalGraph("data/causal-power-imbalance.json");
+      // cache busting query param ensures the latest JSON is loaded
+      initCausalGraph("data/causal-power-imbalance.json?v=" + Date.now());
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- log fetched data and element counts when graph loads
- bust browser cache when loading main JSON
- document console checks in README
- provide minimal sample graph data for testing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68473068afdc8328ac9ac0414b333408