### PR TITLE
Add edge visibility toggles for loop types

### DIFF
--- a/dash/pages/causal-graph.js
+++ b/dash/pages/causal-graph.js
@@ -62,6 +62,25 @@ function initCausalGraph(dataPath) {
       // log element counts to check against the JSON file
       console.log('Graph now has', cy.nodes().length, 'nodes and', cy.edges().length, 'edges');
 
+      const toggleR = document.getElementById('toggle-reinforcing');
+      const toggleB = document.getElementById('toggle-balancing');
+
+      function updateEdgeVisibility() {
+        cy.edges().forEach(function(edge) {
+          var loop = edge.data('loop') || (edge.data('type') === 'negative' ? 'B' : 'R');
+          if ((loop === 'R' && toggleR && !toggleR.checked) || (loop === 'B' && toggleB && !toggleB.checked)) {
+            edge.hide();
+          } else {
+            edge.show();
+          }
+        });
+      }
+
+      if (toggleR) toggleR.addEventListener('change', updateEdgeVisibility);
+      if (toggleB) toggleB.addEventListener('change', updateEdgeVisibility);
+
+      updateEdgeVisibility();
+
       cy.on('tap', 'node', function(evt) {
         if (!sidebar) return;
         var d = evt.target.data();

--- a/index.html
+++ b/index.html
@@ -105,6 +105,16 @@
             <section id="loops" class="mb-16 bg-white p-6 rounded-xl shadow-md">
                 <h2 class="text-2xl font-bold text-center mb-2 text-teal-800">بخش سوم: دینامیک سیستم - حلقه‌های بازخورد معیوب</h2>
                 <p class="text-center text-slate-600 mb-8 max-w-4xl mx-auto">مشکل برق صرفاً مجموعه‌ای از عوامل مجزا نیست، بلکه یک سیستم پویا با حلقه‌های بازخورد تقویت‌کننده است که وضعیت را وخیم‌تر می‌کنند. دیاگرام زیر یکی از این حلقه‌های معیوب کلیدی («حلقه فرسایش سرمایه و ظرفیت») را نشان می‌دهد. برای تعامل، از ابزار زیر استفاده کنید.</p>
+                <div class="flex justify-center gap-6 mb-4">
+                    <label class="flex items-center gap-2">
+                        <input type="checkbox" id="toggle-reinforcing" class="h-4 w-4" checked>
+                        <span class="text-sm">نمایش حلقه‌های تقویتی (R)</span>
+                    </label>
+                    <label class="flex items-center gap-2">
+                        <input type="checkbox" id="toggle-balancing" class="h-4 w-4" checked>
+                        <span class="text-sm">نمایش حلقه‌های تعادلی (B)</span>
+                    </label>
+                </div>
                 <div class="w-full max-w-4xl mx-auto">
                     <div id="cy" class="w-full h-[600px]"></div>
                 </div>


### PR DESCRIPTION
## Summary
- add checkboxes for displaying reinforcing or balancing loops
- use Cytoscape `hide()`/`show()` to toggle edges

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6847a1ba96608328ba4a60436072d1c0