### PR TITLE
Add time slider for timestamped graphs

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,6 +117,10 @@
                 </div>
                 <div class="w-full max-w-4xl mx-auto">
                     <div id="cy" class="w-full h-[600px]"></div>
+                    <div id="time-slider-container" class="mt-4 hidden">
+                        <input id="time-slider" type="range" class="w-full" />
+                        <div id="time-label" class="text-sm text-center mt-1 text-slate-700"></div>
+                    </div>
                 </div>
             </section>
 


### PR DESCRIPTION
## Summary
- add timeline slider markup under the causal graph
- support optional timestamps in `initCausalGraph`
- fade elements in/out based on slider value
- show dates in Persian locale

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6847a2d120f083288323afc86ccf9279