### PR TITLE
Add tabbed node sidebar

### DIFF
--- a/dash/causal-graph.html
+++ b/dash/causal-graph.html
@@ -28,8 +28,22 @@
             <h2 id="node-info-title" class="font-bold text-lg"></h2>
             <button id="node-info-close" class="text-slate-500 hover:text-slate-700">&times;</button>
         </div>
-        <p id="node-info-desc" class="text-sm text-slate-700 mb-4"></p>
-        <ul id="node-info-resources" class="list-disc pr-5 space-y-2 text-sm"></ul>
+        <div>
+            <nav id="node-info-tabs" class="flex mb-4 border-b">
+                <button data-tab="desc" class="tab-button px-3 py-1 border-b-2 active-tab">توضیحات</button>
+                <button data-tab="resources" class="tab-button px-3 py-1 border-b-2 inactive-tab">منابع</button>
+                <button data-tab="loops" class="tab-button px-3 py-1 border-b-2 inactive-tab">حلقه‌های مرتبط</button>
+            </nav>
+            <div id="tab-desc" class="tab-content">
+                <p id="node-info-desc" class="text-sm text-slate-700 mb-4"></p>
+            </div>
+            <div id="tab-resources" class="tab-content hidden">
+                <ul id="node-info-resources" class="list-disc pr-5 space-y-2 text-sm"></ul>
+            </div>
+            <div id="tab-loops" class="tab-content hidden">
+                <ul id="node-info-loops" class="list-disc pr-5 space-y-2 text-sm"></ul>
+            </div>
+        </div>
     </div>
     <script src="pages/causal-graph.js"></script>
     <script>

--- a/dash/pages/causal-graph.js
+++ b/dash/pages/causal-graph.js
@@ -9,12 +9,26 @@ function initCausalGraph(dataPath) {
   const titleEl = document.getElementById('node-info-title');
   const descEl = document.getElementById('node-info-desc');
   const resEl = document.getElementById('node-info-resources');
+  const loopsEl = document.getElementById('node-info-loops');
+  const tabButtons = document.querySelectorAll('#node-info-tabs .tab-button');
+  const tabContents = document.querySelectorAll('#node-info-sidebar .tab-content');
   const closeBtn = document.getElementById('node-info-close');
   if (closeBtn && sidebar) {
     closeBtn.addEventListener('click', function() {
       sidebar.classList.add('translate-x-full');
     });
   }
+
+  tabButtons.forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      tabButtons.forEach(function(b) { b.classList.replace('active-tab', 'inactive-tab'); });
+      tabContents.forEach(function(c) { c.classList.add('hidden'); });
+      btn.classList.replace('inactive-tab', 'active-tab');
+      var tabId = 'tab-' + btn.getAttribute('data-tab');
+      var content = document.getElementById(tabId);
+      if (content) content.classList.remove('hidden');
+    });
+  });
 
   const loadingEl = document.createElement('div');
   let cy;
@@ -113,6 +127,35 @@ function initCausalGraph(dataPath) {
             });
           }
         }
+        if (loopsEl && cy) {
+          loopsEl.innerHTML = '';
+          var loopsSet = new Set();
+          cy.edges().forEach(function(edge) {
+            var data = edge.data();
+            if (data.source === d.id || data.target === d.id) {
+              var l = data.loop || (data.type === 'negative' ? 'B' : 'R');
+              loopsSet.add(l);
+            }
+          });
+          if (loopsSet.size) {
+            loopsSet.forEach(function(l) {
+              var li = document.createElement('li');
+              li.textContent = l === 'R' ? 'حلقه تقویتی' : 'حلقه متعادل‌کننده';
+              loopsEl.appendChild(li);
+            });
+          } else {
+            var li = document.createElement('li');
+            li.textContent = 'حلقه مرتبطی یافت نشد';
+            loopsEl.appendChild(li);
+          }
+        }
+        // reset tabs to description on each open
+        tabButtons.forEach(function(b) { b.classList.replace('active-tab', 'inactive-tab'); });
+        tabContents.forEach(function(c) { c.classList.add('hidden'); });
+        var firstTab = document.querySelector('#node-info-tabs [data-tab="desc"]');
+        if (firstTab) firstTab.classList.replace('inactive-tab', 'active-tab');
+        var firstContent = document.getElementById('tab-desc');
+        if (firstContent) firstContent.classList.remove('hidden');
         sidebar.classList.remove('translate-x-full');
       });
     })

--- a/index.html
+++ b/index.html
@@ -126,8 +126,22 @@
                     <h2 id="node-info-title" class="font-bold text-lg"></h2>
                     <button id="node-info-close" class="text-slate-500 hover:text-slate-700">&times;</button>
                 </div>
-                <p id="node-info-desc" class="text-sm text-slate-700 mb-4"></p>
-                <ul id="node-info-resources" class="list-disc pr-5 space-y-2 text-sm"></ul>
+                <div>
+                    <nav id="node-info-tabs" class="flex mb-4 border-b">
+                        <button data-tab="desc" class="tab-button px-3 py-1 border-b-2 active-tab">توضیحات</button>
+                        <button data-tab="resources" class="tab-button px-3 py-1 border-b-2 inactive-tab">منابع</button>
+                        <button data-tab="loops" class="tab-button px-3 py-1 border-b-2 inactive-tab">حلقه‌های مرتبط</button>
+                    </nav>
+                    <div id="tab-desc" class="tab-content">
+                        <p id="node-info-desc" class="text-sm text-slate-700 mb-4"></p>
+                    </div>
+                    <div id="tab-resources" class="tab-content hidden">
+                        <ul id="node-info-resources" class="list-disc pr-5 space-y-2 text-sm"></ul>
+                    </div>
+                    <div id="tab-loops" class="tab-content hidden">
+                        <ul id="node-info-loops" class="list-disc pr-5 space-y-2 text-sm"></ul>
+                    </div>
+                </div>
             </div>
 
             <section id="solutions" class="bg-teal-50 p-8 rounded-xl border-t-4 border-teal-600">


### PR DESCRIPTION
## Summary
- split node sidebar into Description, Resources, and Related Loops tabs
- add loops list calculation when clicking nodes
- enable tab switching via Tailwind classes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847a36ddc8c83289001dc608218f08f