### PR TITLE
Fix edge visibility in graph

### DIFF
--- a/dash/causal-graph.html
+++ b/dash/causal-graph.html
@@ -6,7 +6,11 @@
     <title>نمودار علّی عرضه و تقاضای برق</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://unpkg.com/cytoscape@3/dist/cytoscape.min.js"></script>
-</head>
+    <style>
+      #cy { position: relative; z-index: 0; }
+      #cy-legend, #cy-controls { z-index: 10; }
+    </style>
+  </head>
 <body class="p-4">
     <div class="relative" style="width:100%; height:600px">
         <div id="cy" class="absolute inset-0"></div>

--- a/dash/pages/causal-graph.js
+++ b/dash/pages/causal-graph.js
@@ -44,6 +44,13 @@ function initCausalGraph(dataPath) {
       console.log('Fetched graph data:', causalData);
       console.log('Edges array from fetch:', causalData.edges);
       console.log('JSON Edges:', causalData.edges);
+
+      // Map relation type to color while preserving the original sign
+      (causalData.edges || []).forEach(function(e) {
+        var sign = e.data.type; // 'positive' or 'negative'
+        e.data.sign = sign;
+        e.data.type = sign === 'positive' ? 'green' : 'red';
+      });
       cy = cytoscape({
         container: container,
         elements: [],
@@ -63,26 +70,10 @@ function initCausalGraph(dataPath) {
           {
             selector: 'edge',
             style: {
-              width: 4,
+              'line-color': 'data(type)',
               'target-arrow-shape': 'triangle',
-              'curve-style': 'bezier',
-              opacity: 1,
-              'transition-property': 'opacity',
-              'transition-duration': '300ms'
-            }
-          },
-          {
-            selector: 'edge[type="positive"]',
-            style: {
-              'line-color': '#16a34a',
-              'target-arrow-color': '#16a34a'
-            }
-          },
-          {
-            selector: 'edge[type="negative"]',
-            style: {
-              'line-color': '#dc2626',
-              'target-arrow-color': '#dc2626'
+              'target-arrow-color': 'data(type)',
+              width: 3
             }
           }
         ],
@@ -106,7 +97,7 @@ function initCausalGraph(dataPath) {
 
       function updateEdgeVisibility() {
         cy.edges().forEach(function(edge) {
-          var loop = edge.data('loop') || (edge.data('type') === 'negative' ? 'B' : 'R');
+          var loop = edge.data('loop') || (edge.data('sign') === 'negative' ? 'B' : 'R');
           if ((loop === 'R' && toggleR && !toggleR.checked) || (loop === 'B' && toggleB && !toggleB.checked)) {
             edge.hide();
           } else {
@@ -161,7 +152,7 @@ function initCausalGraph(dataPath) {
           cy.edges().forEach(function(edge) {
             var data = edge.data();
             if (data.source === d.id || data.target === d.id) {
-              var l = data.loop || (data.type === 'negative' ? 'B' : 'R');
+              var l = data.loop || (data.sign === 'negative' ? 'B' : 'R');
               loopsSet.add(l);
             }
           });
@@ -239,6 +230,7 @@ function addDataToGraph(cy, data) {
     cy.add(newElements);
     console.log('Edges count after add:', cy.edges().length);
     cy.layout({ name: 'cose' }).run();
+    if (cy.forceRender) cy.forceRender();
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -28,6 +28,8 @@
         .fade-in { animation: fadeIn 0.5s ease-in-out; }
         @keyframes fadeIn { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: translateY(0); } }
         .loop-tooltip { position: absolute; background: #fff; border: 1px solid #000; padding: 2px 4px; font-size: 12px; pointer-events: none; z-index: 1000; }
+        #cy { position: relative; z-index: 0; }
+        #cy-legend, #cy-controls { z-index: 10; }
     </style>
 </head>
 <body class="bg-slate-50 text-slate-800">


### PR DESCRIPTION
## Summary
- ensure edge styling uses selector and color mapped from data
- preserve original relation sign on edges
- call `forceRender` after layout
- set z-indexes for Cytoscape container and overlays

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6847a75648988328a5d443955783124b