### PR TITLE
Add edge visibility toggles

### DIFF
--- a/dash/causal-graph.html
+++ b/dash/causal-graph.html
@@ -25,10 +25,20 @@
                 <span class="w-3 h-3 rounded-full bg-red-600 mr-2 inline-block"></span>
             </div>
         </div>
-        <div id="cy-controls" class="absolute top-2 right-2 flex gap-1">
-            <button id="zoom-in" class="bg-white px-2 py-1 rounded shadow">+</button>
-            <button id="zoom-out" class="bg-white px-2 py-1 rounded shadow">−</button>
-            <button id="reset-zoom" class="bg-white px-2 py-1 rounded shadow">↺</button>
+        <div id="cy-controls" class="absolute top-2 right-2 flex flex-col items-end gap-1">
+            <div class="flex gap-1">
+                <button id="zoom-in" class="bg-white px-2 py-1 rounded shadow">+</button>
+                <button id="zoom-out" class="bg-white px-2 py-1 rounded shadow">−</button>
+                <button id="reset-zoom" class="bg-white px-2 py-1 rounded shadow">↺</button>
+            </div>
+            <label class="bg-white px-2 py-1 rounded shadow text-xs flex items-center gap-1">
+                <input type="checkbox" id="toggle-reinforcing" class="mr-1" checked>
+                <span>نمایش حلقه‌های تقویتی (R)</span>
+            </label>
+            <label class="bg-white px-2 py-1 rounded shadow text-xs flex items-center gap-1">
+                <input type="checkbox" id="toggle-balancing" class="mr-1" checked>
+                <span>نمایش حلقه‌های تعادلی (B)</span>
+            </label>
         </div>
     </div>
     <button id="add-data-btn" class="mt-2 px-4 py-1 bg-blue-600 text-white rounded">افزودن داده</button>

--- a/dash/pages/causal-graph.js
+++ b/dash/pages/causal-graph.js
@@ -96,14 +96,20 @@ function initCausalGraph(dataPath) {
       const zoomResetBtn = document.getElementById('zoom-reset');
 
       function updateEdgeVisibility() {
-        cy.edges().forEach(function(edge) {
-          var loop = edge.data('loop') || (edge.data('sign') === 'negative' ? 'B' : 'R');
-          if ((loop === 'R' && toggleR && !toggleR.checked) || (loop === 'B' && toggleB && !toggleB.checked)) {
-            edge.hide();
-          } else {
-            edge.show();
-          }
-        });
+        var edges = cy.edges();
+        edges.hide();
+        if (toggleR && toggleR.checked) {
+          edges.filter(function(edge){
+            var loop = edge.data('loop') || (edge.data('sign') === 'negative' ? 'B' : 'R');
+            return loop === 'R';
+          }).show();
+        }
+        if (toggleB && toggleB.checked) {
+          edges.filter(function(edge){
+            var loop = edge.data('loop') || (edge.data('sign') === 'negative' ? 'B' : 'R');
+            return loop === 'B';
+          }).show();
+        }
       }
 
       if (toggleR) toggleR.addEventListener('change', updateEdgeVisibility);


### PR DESCRIPTION
## Summary
- add checkboxes for showing Reinforcing and Balancing loops
- hide/show edges using cy.edges().filter()

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847aa2f0b08832899c5ed09edc6a87e