### PR TITLE
Fix async init timing for causal graph

### DIFF
--- a/dash/causal-graph.html
+++ b/dash/causal-graph.html
@@ -83,22 +83,23 @@
     </div>
     <script src="pages/causal-graph.js"></script>
     <script>
-  const cy = initCausalGraph('../data/causal-power-imbalance.json');
-  // Temporary edge style test
-  cy.style()
-    .selector('edge')
-    .style({
-      'line-color': 'red',
-      'width': 4,
-      'target-arrow-shape': 'triangle'
-    })
-    .update();
-  document.getElementById('add-data-btn')
-    .addEventListener('click', () => {
-      fetch('../data/new-elements.json')
-        .then(res => res.json())
-        .then(data => addDataToGraph(cy, data));
-    });
+  initCausalGraph('../data/causal-power-imbalance.json').then(cy => {
+    // Temporary edge style test
+    cy.style()
+      .selector('edge')
+      .style({
+        'line-color': 'red',
+        'width': 4,
+        'target-arrow-shape': 'triangle'
+      })
+      .update();
+    document.getElementById('add-data-btn')
+      .addEventListener('click', () => {
+        fetch('../data/new-elements.json')
+          .then(res => res.json())
+          .then(data => addDataToGraph(cy, data));
+      });
+  });
 
   const helpBtn = document.getElementById('graph-help-btn');
   const helpModal = document.getElementById('graph-help-modal');

--- a/dash/pages/causal-graph.js
+++ b/dash/pages/causal-graph.js
@@ -1,9 +1,11 @@
 function initCausalGraph(dataPath) {
-  const container = document.getElementById('cy');
-  if (!container) {
-    console.error('Container element with id "cy" not found');
-    return;
-  }
+  return new Promise(function(resolve, reject) {
+    const container = document.getElementById('cy');
+    if (!container) {
+      console.error('Container element with id "cy" not found');
+      reject(new Error('Container element with id "cy" not found'));
+      return;
+    }
   const sliderContainer = document.getElementById('time-slider-container');
   const slider = document.getElementById('time-slider');
   const sliderLabel = document.getElementById('time-label');
@@ -193,16 +195,19 @@ function initCausalGraph(dataPath) {
           cy.edges().removeClass('highlight faded');
         }
       });
+
+      resolve(cy);
     })
     .catch(function(err) {
       console.error('Error loading graph data', err);
       container.innerHTML = '<div class="text-red-600">خطا در بارگذاری داده‌های نمودار</div>';
+      reject(err);
     })
     .finally(function() {
       loadingEl.remove();
     });
+  });
 
-  return cy;
 }
 
 window.initCausalGraph = initCausalGraph;


### PR DESCRIPTION
## Summary
- initialize `cytoscape` instance asynchronously
- wait for `initCausalGraph` promise before accessing graph in `causal-graph.html`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6847ad1b5eb483288c6a362711beea9c