### PR TITLE
Implement tabbed sidebar for graph

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,8 +110,37 @@
                 <h2 class="text-2xl font-bold text-center mb-2 text-teal-800">بخش سوم: دینامیک سیستم - حلقه‌های بازخورد معیوب</h2>
                 <p class="text-center text-slate-600 mb-8 max-w-4xl mx-auto">مشکل برق صرفاً مجموعه‌ای از عوامل مجزا نیست، بلکه یک سیستم پویا با حلقه‌های بازخورد تقویت‌کننده است که وضعیت را وخیم‌تر می‌کنند. دیاگرام زیر یکی از این حلقه‌های معیوب کلیدی («حلقه فرسایش سرمایه و ظرفیت») را نشان می‌دهد. برای تعامل، از ابزار زیر استفاده کنید.</p>
 
-
+                <div class="relative" style="width:100%; height:600px">
+                    <div id="cy" class="absolute inset-0"></div>
+                    <div id="cy-legend" class="absolute bottom-2 right-2 bg-white/80 backdrop-blur-sm rounded-md shadow px-3 py-2 text-xs">
+                        <div class="flex items-center mb-1">
+                            <span class="text-xs">رابطه مثبت (تقویتی)</span>
+                            <span class="w-3 h-3 rounded-full bg-green-600 mr-2 inline-block"></span>
+                        </div>
+                        <div class="flex items-center">
+                            <span class="text-xs">رابطه منفی (متعادل‌کننده)</span>
+                            <span class="w-3 h-3 rounded-full bg-red-600 mr-2 inline-block"></span>
+                        </div>
                     </div>
+                    <div id="cy-controls" class="absolute top-2 right-2 flex flex-col items-end gap-1">
+                        <div class="flex gap-1">
+                            <button id="zoom-in" class="bg-white px-2 py-1 rounded shadow">+</button>
+                            <button id="zoom-out" class="bg-white px-2 py-1 rounded shadow">−</button>
+                            <button id="reset-zoom" class="bg-white px-2 py-1 rounded shadow">↺</button>
+                        </div>
+                        <label class="bg-white px-2 py-1 rounded shadow text-xs flex items-center gap-1">
+                            <input type="checkbox" id="toggle-reinforcing" class="mr-1" checked>
+                            <span>نمایش حلقه‌های تقویتی (R)</span>
+                        </label>
+                        <label class="bg-white px-2 py-1 rounded shadow text-xs flex items-center gap-1">
+                            <input type="checkbox" id="toggle-balancing" class="mr-1" checked>
+                            <span>نمایش حلقه‌های تعادلی (B)</span>
+                        </label>
+                    </div>
+                </div>
+                <div class="mt-2 text-left">
+                    <button id="graph-help-btn" class="px-2 py-1 bg-teal-600 text-white rounded">راهنما</button>
+                </div>
             </section>
 
             <!-- Sidebar for node details -->
@@ -120,7 +149,21 @@
                     <h2 id="node-info-title" class="font-bold text-lg"></h2>
                     <button id="node-info-close" class="text-slate-500 hover:text-slate-700">&times;</button>
                 </div>
-
+                <div>
+                    <nav id="node-info-tabs" class="flex mb-4 border-b">
+                        <button data-tab="desc" class="tab-button px-3 py-1 border-b-2 active-tab">توضیحات</button>
+                        <button data-tab="resources" class="tab-button px-3 py-1 border-b-2 inactive-tab">منابع</button>
+                        <button data-tab="loops" class="tab-button px-3 py-1 border-b-2 inactive-tab">حلقه‌های مرتبط</button>
+                    </nav>
+                    <div id="tab-desc" class="tab-content">
+                        <p id="node-info-desc" class="text-sm text-slate-700 mb-4"></p>
+                    </div>
+                    <div id="tab-resources" class="tab-content hidden">
+                        <ul id="node-info-resources" class="list-disc pr-5 space-y-2 text-sm"></ul>
+                    </div>
+                    <div id="tab-loops" class="tab-content hidden">
+                        <ul id="node-info-loops" class="list-disc pr-5 space-y-2 text-sm"></ul>
+                    </div>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
- add graph container with legend, controls and help button on home page
- implement three-tab sidebar for node details showing description, resources and loops

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847ade6ec3c8328b236f521adfa1063