### PR TITLE
Fix graph init and load logs

### DIFF
--- a/dash/causal-graph.html
+++ b/dash/causal-graph.html
@@ -81,5 +81,8 @@
         </div>
     </div>
 
+    <script src="https://unpkg.com/cytoscape/dist/cytoscape.min.js"></script>
+    <script src="dash/pages/causal-graph.js"></script>
+
 </body>
 </html>

--- a/dash/pages/causal-graph.js
+++ b/dash/pages/causal-graph.js
@@ -1,3 +1,14 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const containerCheck = document.getElementById('cy');
+  if (!containerCheck) {
+    console.error('Container #cy not found');
+    return;
+  }
+  initCausalGraph('data/causal-power-imbalance.json').then(cy => {
+    window.cyInstance = cy;
+  });
+});
+
 function initCausalGraph(dataPath) {
   return new Promise(function(resolve, reject) {
     const container = document.getElementById('cy');
@@ -98,9 +109,16 @@ function initCausalGraph(dataPath) {
         layout: { name: 'cose' }
       });
 
-      console.log('Nodes:', (causalData.nodes || []).length,
-                  'Edges:', (causalData.edges || []).length);
+      console.log('Loaded nodes:', (causalData.nodes || []).length,
+                  'edges:', (causalData.edges || []).length);
+      console.log('Before add:', cy.elements().length);
       cy.add([...(causalData.nodes || []), ...(causalData.edges || [])]);
+      console.log('After add:', cy.elements().length);
+      cy.style().selector('edge').style({
+        'line-color': '#555',
+        'width': 2,
+        'target-arrow-shape': 'triangle'
+      }).update();
       cy.layout({ name: 'cose' }).run();
       cy.resize();
       cy.fit();
@@ -273,16 +291,3 @@ function addDataToGraph(cy, data) {
 }
 
 window.addDataToGraph = addDataToGraph;
-
-
-
-document.addEventListener("DOMContentLoaded", () => {
-  const cyContainer = document.getElementById("cy");
-  if (!cyContainer) {
-    console.warn("Container #cy not found—skipping graph init");
-  } else {
-    initCausalGraph("data/causal-power-imbalance.json").then(cy => {
-      window.cyInstance = cy;
-    });
-  }
-});

--- a/index.html
+++ b/index.html
@@ -363,5 +363,7 @@
         }
       });
     </script>
+    <script src="https://unpkg.com/cytoscape/dist/cytoscape.min.js"></script>
+    <script src="dash/pages/causal-graph.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- run init only after DOM fully loaded and check container
- log data counts when loading graph
- include Cytoscape CDN before causal graph script
- simple edge style fallback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847b1f1bf4483289780522e9cd7c685