### PR TITLE
Add automated release script

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,8 @@ If the counts differ, check that `data/causal-power-imbalance.json` is up to dat
 - Dependencies (Cytoscape.js, Tailwind) loaded via CDN
 - Node details shown in a sidebar when clicked
 - Works completely offline with a simple static server
+
+## Release script
+
+Run `node scripts/release.js <major|minor|patch>` or set `BUMP` env var to bump the version, tag, push and create a GitHub release. The script reads release notes from `CHANGELOG.md` (section `## vX.Y.Z`) and appends a demo link from `package.json` if present.
+

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const { execSync, spawnSync } = require('child_process');
+
+function run(cmd) {
+  try {
+    return execSync(cmd, { stdio: ['pipe', 'pipe', 'inherit'], encoding: 'utf8' }).trim();
+  } catch (err) {
+    if (err.stdout) process.stdout.write(err.stdout);
+    if (err.stderr) process.stderr.write(err.stderr);
+    process.exit(1);
+  }
+}
+
+function fail(msg) {
+  console.error(msg);
+  process.exit(1);
+}
+
+const pkgPath = 'package.json';
+const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+const currentVersion = pkg.version;
+
+const bump = process.env.BUMP || process.argv[2];
+if (!['major', 'minor', 'patch'].includes(bump)) {
+  fail('Usage: BUMP=major|minor|patch node scripts/release.js');
+}
+
+const parts = currentVersion.split('.').map(Number);
+let newVersion;
+if (bump === 'major') newVersion = `${parts[0] + 1}.0.0`;
+if (bump === 'minor') newVersion = `${parts[0]}.${parts[1] + 1}.0`;
+if (bump === 'patch') newVersion = `${parts[0]}.${parts[1]}.${parts[2] + 1}`;
+
+if (newVersion === currentVersion) {
+  fail('Version did not change.');
+}
+
+const existingTag = run(`git tag --list v${newVersion}`);
+if (existingTag) {
+  fail(`Tag v${newVersion} already exists.`);
+}
+
+pkg.version = newVersion;
+fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+
+run(`git add ${pkgPath}`);
+run(`git commit -m "chore(release): v${newVersion}"`);
+run(`git tag v${newVersion}`);
+run(`git push origin HEAD`);
+run(`git push origin v${newVersion}`);
+
+let notes = '';
+const changelogPath = 'CHANGELOG.md';
+if (fs.existsSync(changelogPath)) {
+  const changelog = fs.readFileSync(changelogPath, 'utf8');
+  const regex = new RegExp(`##\\s*v?${newVersion.replace(/\./g, '\\.')}(?:\\s*\n)([\\s\\S]*?)(?=\n##\\s*v|$)`);
+  const match = changelog.match(regex);
+  if (match) {
+    notes = match[1].trim();
+  }
+}
+
+const demo = pkg.demo || pkg.homepage;
+if (demo) {
+  notes += (notes ? '\n\n' : '') + `Demo: ${demo}`;
+}
+
+const gh = spawnSync('gh', ['release', 'create', `v${newVersion}`, '-t', `v${newVersion}`, '-F', '-'], {
+  input: notes,
+  stdio: ['pipe', 'inherit', 'inherit']
+});
+if (gh.status !== 0) {
+  fail('Failed to create GitHub release.');
+}
+


### PR DESCRIPTION
## Summary
- add `scripts/release.js` for bumping version, tagging, pushing, and creating a GitHub release
- document usage in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847c38a67888328bce9e723615b303f