### PR TITLE
Fix 404 errors for causal graph data

### DIFF
--- a/dash/causal-graph.html
+++ b/dash/causal-graph.html
@@ -85,7 +85,10 @@
     <script src="pages/causal-graph.js"></script>
     <script>
       document.addEventListener('DOMContentLoaded', () => {
-        initCausalGraph('/wesh/data/causal-power-imbalance.json');
+        // Load data from the repository root rather than a hard coded
+        // "/wesh" sub-path to avoid 404 errors when the project is served
+        // from its own root directory.
+        initCausalGraph('/data/causal-power-imbalance.json');
       });
     </script>
 

--- a/dash/pages/causal-graph.js
+++ b/dash/pages/causal-graph.js
@@ -4,7 +4,9 @@ document.addEventListener('DOMContentLoaded', () => {
     console.error('Container #cy not found');
     return;
   }
-  initCausalGraph('/wesh/data/causal-power-imbalance.json').then(cy => {
+  // Use a path relative to the server root so the file loads correctly
+  // regardless of where the project directory is served from.
+  initCausalGraph('/data/causal-power-imbalance.json').then(cy => {
     window.cyInstance = cy;
   });
 });


### PR DESCRIPTION
## Summary
- fix path to causal graph JSON so it loads correctly
- add explanatory comments
- add empty `favicon.ico` placeholder to suppress browser 404s

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847c6fff9bc8328a902b1c98ce4dc1a