### PR TITLE
Fix GitHub Pages path

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ npm test          # run Jest tests
 npm run build:css # compile Tailwind CSS
 ```
 
+### Deployment
+
+The `public/` folder contains the static site that is published to GitHub Pages.
+Ensure the Pages source is set to the `gh-pages` branch, which is populated from
+`public/` by the workflow in `.github/workflows`. If Pages shows the README
+instead of the dashboard, check that the workflow has pushed the latest
+`public/index.html`.
+
 
 
 ## Testing

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,3 +1,22 @@
+import react from 'eslint-plugin-react';
+import globals from 'globals';
 
+export default [
+  {
+    files: ['src/**/*.js', 'test/**/*.js'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+        ...globals.jest,
+      },
+    },
+    plugins: { react },
+    settings: {
+      react: { version: 'detect' },
+    },
+    rules: {},
   },
 ];

--- a/examples/cld-tool/package.json
+++ b/examples/cld-tool/package.json
@@ -6,6 +6,6 @@
     "start": "echo 'start step (customize as needed)'",
     "test": "echo 'no test defined'",
     "lint": "echo 'lint step (customize as needed)'"
-  },
+  }
 
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "format": "prettier --write 'src/**/*.{js,ts,json,md}'",
     "release": "semantic-release",
     "prepare": "husky install",
+    "build": "npm run build:css",
     "build:css": "postcss src/styles/tailwind.css -o public/assets/tailwind.css"
   },
   "author": "",


### PR DESCRIPTION
## Summary
- add GH Pages deployment notes to README
- run tailwind build with `npm run build`
- repair ESLint config
- fix example `package.json`
- add `.nojekyll` so Pages serves HTML

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68481335dc1c832889040e5ddb9a6845