### PR TITLE
Fix GitHub Pages deployments

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -25,7 +25,10 @@ jobs:
       - run: npm run lint
       - run: npm test
       - run: npm run build
+      - run: npm run verify:pages
       - uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
+          keep_files: false
+          force_orphan: true

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -2,11 +2,7 @@
 name: Deploy Jekyll with GitHub Pages dependencies preinstalled
 
 on:
-  # Runs on pushes targeting the default branch
-  push:
-    branches: ["main"]
-
-  # Allows you to run this workflow manually from the Actions tab
+  # Disabled automatic deploys - run manually if needed
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -2,11 +2,7 @@
 name: Deploy static content to Pages
 
 on:
-  # Runs on pushes targeting the default branch
-  push:
-    branches: ["main"]
-
-  # Allows you to run this workflow manually from the Actions tab
+  # Disabled automatic deploys - run manually if needed
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/README.md
+++ b/README.md
@@ -90,6 +90,17 @@ Ensure the Pages source is set to the `gh-pages` branch, which is populated from
 instead of the dashboard, check that the workflow has pushed the latest
 `public/index.html`.
 
+### Troubleshooting GitHub Pages
+
+If the site ever loads the repository `README.md` instead of `public/index.html`:
+
+1. Run `npm run verify:pages` locally or check the CI logs to ensure `public/index.html` exists and no `index.html` is present in the repo root.
+2. Confirm that only `.github/workflows/deploy-pages.yml` runs automatically. Other workflows such as `jekyll-gh-pages.yml` or `static.yml` should be disabled or manual so they do not overwrite the `gh-pages` branch.
+3. In GitHub Pages settings, verify the source is the `gh-pages` branch and directory `/`.
+4. If an old deployment is cached, briefly disable and re-enable GitHub Pages or append a query string like `?cache=bust` to the site URL to invalidate the CDN cache.
+5. Ensure the default branch is set to `main` and that no branch protection rules prevent the Pages workflow from pushing to `gh-pages`.
+6. After fixing the above, trigger a fresh deploy on the `main` branch.
+
 
 
 ## Testing

--- a/package.json
+++ b/package.json
@@ -4,14 +4,14 @@
   "description": "Causal Graph Visualization project",
   "main": "index.js",
   "scripts": {
-
     "test": "jest",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "format": "prettier --write 'src/**/*.{js,ts,json,md}'",
     "release": "semantic-release",
     "prepare": "husky install",
     "build": "npm run build:css",
-    "build:css": "postcss src/styles/tailwind.css -o public/assets/tailwind.css"
+    "build:css": "postcss src/styles/tailwind.css -o public/assets/tailwind.css",
+    "verify:pages": "bash scripts/verify-pages.sh"
   },
   "author": "",
   "license": "MIT",

--- a/scripts/verify-pages.sh
+++ b/scripts/verify-pages.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -e
+
+# Fail if an index.html exists in repository root (outside public)
+if [ -f index.html ]; then
+  echo "Root index.html detected; remove it to prevent GitHub Pages fallback." >&2
+  exit 1
+fi
+
+# Ensure built index exists under public/
+if [ ! -f public/index.html ]; then
+  echo "public/index.html is missing. Build step did not produce output." >&2
+  exit 1
+fi
+
+# Optionally check that .nojekyll exists
+if [ ! -f public/.nojekyll ]; then
+  echo ".nojekyll not found; creating it." >&2
+  touch public/.nojekyll
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- deploy only from `public` and remove old files
- add verification step for index.html
- disable unused Pages workflows
- document troubleshooting steps in README

## Testing
- `npm ci`
- `npm test`
- `npm run lint` *(fails: SyntaxError in eslint.config.js)*
- `npm run verify:pages`

------
https://chatgpt.com/codex/tasks/task_e_68482a1c0cf883288daae9234c0b2bea