### PR TITLE
Fix GitHub Pages permissions

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -2,6 +2,10 @@ name: Deploy Pages
 on:
   push:
     branches: [main]
+permissions:
+  contents: write
+  pages: write
+  id-token: write
 concurrency:
   group: pages-deploy-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -7,7 +7,7 @@ on:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -7,7 +7,7 @@ on:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 


### PR DESCRIPTION
## Summary
- enable push permissions for deployment workflows

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684830a971548328b72bf77d30182b46