### PR TITLE
Update Node version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: '20.8.1'
       - run: npm ci
       - run: bash scripts/ensure-remote.sh
       - run: npm run release


### PR DESCRIPTION
## Summary
- update `.github/workflows/release.yml` to use Node 20.8.1

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68484d3d4d7083289ab49a11febcd5eb